### PR TITLE
Fix for recent freetype-go issues

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,1 +1,2 @@
 John Asmuth <jasmuth@gmail.com>
+Cory Mainwaring <olreich@gmail.com>

--- a/fonts.go
+++ b/fonts.go
@@ -31,8 +31,9 @@ var DefaultFontData = draw2d.FontData{
 
 func GetFontHeight(fd draw2d.FontData, size float64) (height float64) {
 	font := draw2d.GetFont(fd)
-	bounds := font.Bounds()
-	height = float64(bounds.YMax-bounds.YMin) * size / float64(font.UnitsPerEm())
+	fupe := font.FUnitsPerEm()
+	bounds := font.Bounds(fupe)
+	height = float64(bounds.YMax-bounds.YMin) * size / float64(fupe)
 	return
 }
 


### PR DESCRIPTION
Changing in response to freetype-go changing their scaling of stuff.
They switched up the scaling factors, so now you need to get
FUnitsPerEm() and send that to font.Bounds() and use that where you
would before have used UnitsPerEm(). Seems a bit silly. Still, fixed.
